### PR TITLE
Add equation numbering, referencing, and accessibility features

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -6,6 +6,7 @@ import {CompilerOptionOverride, runCompiler} from "../src";
 import AsyncLock from 'async-lock'
 import chokidar from "chokidar";
 import consola from "consola";
+import { createServer, ServerResponse } from "node:http";
 
 
 const version = "v0.1.6";
@@ -43,8 +44,11 @@ program.command('version')
 
 
 const compileLock = new AsyncLock({maxPending: 2});
-function compile(options: CompilerOptionOverride) {
-    compileLock.acquire('compile', () => runCompiler(options)).catch(() => {});
+function compile(options: CompilerOptionOverride, onDone?: () => void) {
+    compileLock.acquire('compile', async () => {
+        await runCompiler(options);
+        onDone?.();
+    }).catch(() => {});
 }
 
 program.command('watch')
@@ -59,20 +63,41 @@ program.command('watch')
         process.env.PORT = String(opts.port);
 
         consola.info(`Spec ${version}. Watching the current directory...`);
-        
+
         // @ts-ignore
         import('../../.output/server/index.mjs');
+
+        // SSE server for live reload: browsers connect and get notified after each recompile.
+        const sseClients = new Set<ServerResponse>();
+        const liveReloadPort = opts.port + 1;
+        createServer((req, res) => {
+            res.writeHead(200, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                'Connection': 'keep-alive',
+                'Access-Control-Allow-Origin': '*',
+            });
+            sseClients.add(res);
+            req.on('close', () => sseClients.delete(res));
+        }).listen(liveReloadPort);
+        consola.info(`Live reload server on port ${liveReloadPort}.`);
+
+        const notifyReload = () => {
+            for (const client of sseClients) {
+                client.write('data: reload\n\n');
+            }
+        };
 
         chokidar.watch('.', {
             ignoreInitial: true,
             ignored: (path, stats) => !!stats?.isFile() && !/\.(tex|sty|bib)$/.test(path)
         }).on('add', () => compile({
             compileAll: opts.all
-        })).on('change', () => compile({
+        }, notifyReload)).on('change', () => compile({
             compileAll: opts.all
-        })).on('unlink', () => compile({
+        }, notifyReload)).on('unlink', () => compile({
             compileAll: opts.all
-        }))
+        }, notifyReload))
     })
 
 program.parse();

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,8 @@
 import {MetaProvider} from "@solidjs/meta";
 import {Router} from "@solidjs/router";
 import {FileRoutes} from "@solidjs/start/router";
-import {Suspense} from "solid-js";
+import {Suspense, onMount} from "solid-js";
+import {isServer} from "solid-js/web";
 
 import "@fontsource/roboto";
 import "@fontsource/open-sans";
@@ -13,6 +14,44 @@ import "./colours.css";
 import {DarkThemeProvider} from "./theme";
 
 export default function App() {
+    // Connect to the live-reload SSE server (started by `spec watch` on port+1).
+    // In production or with `spec serve`, the connection silently fails.
+    onMount(() => {
+        if (isServer) return;
+        try {
+            const port = parseInt(window.location.port || '3000') + 1;
+            const url = `http://${window.location.hostname}:${port}`;
+            let retries = 0;
+            const connect = () => {
+                const es = new EventSource(url);
+                es.onmessage = async () => {
+                    try {
+                        // Check the current page still exists before reloading.
+                        const resp = await fetch(window.location.href, { cache: 'no-store' });
+                        if (resp.ok) {
+                            window.location.reload();
+                        } else {
+                            // Tag changed — page no longer exists. Go home.
+                            window.location.href = '/';
+                        }
+                    } catch {
+                        window.location.reload();
+                    }
+                };
+                es.onerror = () => {
+                    es.close();
+                    // Reconnect with backoff, up to 5 attempts.
+                    if (retries < 5) {
+                        retries++;
+                        setTimeout(connect, 1000 * retries);
+                    }
+                };
+                es.onopen = () => { retries = 0; };
+            };
+            connect();
+        } catch {}
+    });
+
     return (
         <Router
             root={props => (

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -36,6 +36,9 @@ import {
 } from "./renderer";
 import {unifiedLatexToHast} from "@unified-latex/unified-latex-to-hast";
 import rehypeStringify from "rehype-stringify";
+import {visit} from "@unified-latex/unified-latex-util-visit";
+import {match} from "@unified-latex/unified-latex-util-match";
+import {toTagString} from "../tag";
 import {documentDividers, macrosToOmit} from "../unit-types";
 import {UnitData} from "../db/unit-data";
 import {BibliographyData} from "../db/bib-data";
@@ -158,6 +161,7 @@ export class Compiler {
         this.assignBlockMetadata();
 
         this.collectUnits();
+        this.resolveEquationLinks();
         this.computeUnitReferences();
 
         const result = {
@@ -251,6 +255,40 @@ export class Compiler {
             ...Array.from(this.divisions.entries()),
             ...Array.from(this.blocks.entries()),
         ]);
+    }
+
+    // After units are collected, map equation tags to their containing unit's tag.
+    // Then update refMeta on ref macros that point to equations, so they link
+    // to the parent unit's page with an anchor to the equation element.
+    resolveEquationLinks() {
+        const equationParentMap = new Map<number, number>();
+
+        // Scan each unit's content for tagged nodes that are NOT units (i.e. equations).
+        const scanForEquations = (nodes: Node[], unitTag: number) => {
+            for (const node of nodes) {
+                const meta = node.meta as any;
+                if (meta && meta.tag !== undefined && !this.units.has(meta.tag)) {
+                    equationParentMap.set(meta.tag, unitTag);
+                }
+                if ('content' in node && Array.isArray((node as any).content)) {
+                    scanForEquations((node as any).content, unitTag);
+                }
+            }
+        };
+
+        for (const [unitTag, unit] of this.units) {
+            scanForEquations(unit.mainContent, unitTag);
+        }
+
+        // Walk the document and update refMeta for refs that target equations.
+        visit(this.documentRoot!, (node) => {
+            if (!match.anyMacro(node) || !node.refMeta) return;
+            const targetTag = node.refMeta.targetTag;
+            if (targetTag >= 0 && equationParentMap.has(targetTag)) {
+                node.refMeta.parentTag = equationParentMap.get(targetTag)!;
+                node.refMeta.anchor = `eq-${toTagString(targetTag)}`;
+            }
+        });
     }
 
     computeUnitReferences() {
@@ -357,6 +395,11 @@ export class Compiler {
         envCollector.process(this.documentRoot!);
         this.blockTypes = envCollector.blockTypes;
 
+        // Register equation counter and environment for numbering.
+        if (!this.countManager.hasCounter('equation')) {
+            this.countManager.addCounter('equation', 'chapter');
+        }
+
         const macroCollector = new CustomMacroCollector({ logger: definitionLogger });
         macroCollector.process(this.documentRoot!);
         this.rawMacros = macroCollector.rawMacros;
@@ -404,8 +447,10 @@ export class Compiler {
         const tagLogger = new ParserLogger({ parent: this.logger });
         tagLogger.info('Assigning tags to divisions and blocks.');
 
+        const equationEnvs = new Set<string>(['equation', 'align', 'multline', 'gather', 'flalign']);
         const tagAssigner = new TagAssigner({
-            taggableEnvironments: new Set<string>(this.blockTypes.keys()),
+            taggableEnvironments: new Set<string>([...this.blockTypes.keys(), ...equationEnvs]),
+            nonUnitEnvironments: equationEnvs,
             taggableMacros: new Set<string>(documentDividers),
             labelTagMap: this.unitLabelTags,
             nextAvailableTag: this.nextAvailableTag,
@@ -429,8 +474,14 @@ export class Compiler {
 
         const numberer = new Numberer({
             countManager: this.countManager, logger: numberLogger,
-            environmentCounters: new Map<string, string>(
-                [...this.blockTypes.entries()].map(([k, v]) => [k, v.associatedCounter]))
+            environmentCounters: new Map<string, string>([
+                ...[...this.blockTypes.entries()].map(([k, v]) => [k, v.associatedCounter] as [string, string]),
+                ['equation', 'equation'],
+                ['align', 'equation'],
+                ['multline', 'equation'],
+                ['gather', 'equation'],
+                ['flalign', 'equation']
+            ])
         });
         numberer.process(this.documentRoot!);
 
@@ -465,7 +516,14 @@ export class Compiler {
             tagNodeMap: this.unitTagNode,
             labelTagMap: this.unitLabelTags,
             macroNames: new Map<string, string>([...documentDividers].map((d) => [d, capitaliseFirstLetter(d)])),
-            environmentNames: new Map<string, string>([...this.blockTypes.entries()].map(([k, v]) => [k, v.name])),
+            environmentNames: new Map<string, string>([
+                ...[...this.blockTypes.entries()].map(([k, v]) => [k, v.name] as [string, string]),
+                ['equation', 'Equation'],
+                ['align', 'Equation'],
+                ['multline', 'Equation'],
+                ['gather', 'Equation'],
+                ['flalign', 'Equation']
+            ]),
             logger: linkLogger
         });
         refAssigner.process(this.documentRoot!);

--- a/src/compiler/grouping/division.ts
+++ b/src/compiler/grouping/division.ts
@@ -51,10 +51,22 @@ export class Division extends IRUnit {
         };
     }
 
+    // Build a recursive LinkTarget tree so that a chapter's children list includes
+    // subsections nested under sections, and subsubsections nested under subsections.
+    private recursiveLinkTarget(div: Division): import("../../db/link-target").LinkTarget {
+        const target = { ...div.linkTarget! };
+        if (div.children.length > 0) {
+            target.children = div.children.map((c) => this.recursiveLinkTarget(c));
+        }
+        return target;
+    }
+
     renderToUnitData(allUnits: Map<number, IRUnit>, renderer: (node: Node) => string): UnitData {
         const data = super.renderToUnitData(allUnits, renderer);
 
-        data.children = this.children.length ? this.children.map((c) => c.linkTarget!) : null;
+        data.children = this.children.length
+            ? this.children.map((c) => this.recursiveLinkTarget(c))
+            : null;
 
         return data;
     }

--- a/src/compiler/grouping/unit.ts
+++ b/src/compiler/grouping/unit.ts
@@ -168,10 +168,10 @@ export abstract class IRUnit {
 
             parentChain: [...this.parentTagChain()].map((r) => allUnits.get(r)!.linkTarget!),
 
-            directlyReferences: [...this.directReferences].map((r) => allUnits.get(r)!.linkTarget!),
-            indirectlyReferences: this.indirectReferences ? [...this.indirectReferences].map((r) => allUnits.get(r)!.linkTarget!) : [],
-            directlyReferencedBy: [...this.directlyReferencedBy].map((r) => allUnits.get(r)!.linkTarget!),
-            indirectlyReferencedBy: [...this.indirectlyReferencedBy].map((r) => allUnits.get(r)!.linkTarget!),
+            directlyReferences: [...this.directReferences].filter((r) => allUnits.has(r)).map((r) => allUnits.get(r)!.linkTarget!),
+            indirectlyReferences: this.indirectReferences ? [...this.indirectReferences].filter((r) => allUnits.has(r)).map((r) => allUnits.get(r)!.linkTarget!) : [],
+            directlyReferencedBy: [...this.directlyReferencedBy].filter((r) => allUnits.has(r)).map((r) => allUnits.get(r)!.linkTarget!),
+            indirectlyReferencedBy: [...this.indirectlyReferencedBy].filter((r) => allUnits.has(r)).map((r) => allUnits.get(r)!.linkTarget!),
         });
     }
 }

--- a/src/compiler/loader.ts
+++ b/src/compiler/loader.ts
@@ -3,12 +3,21 @@ import {Macro, Node, Root} from "@unified-latex/unified-latex-types";
 import {match} from "@unified-latex/unified-latex-util-match";
 import path, {join} from "node:path";
 import {readFile} from "node:fs/promises";
-import {parse} from "@unified-latex/unified-latex-util-parse";
+import {getParser} from "@unified-latex/unified-latex-util-parse";
 import {visit} from "@unified-latex/unified-latex-util-visit";
 import {printRaw} from "@unified-latex/unified-latex-util-print-raw";
 
 const packageCommands = ['usepackage', 'RequirePackage']
 const inputCommands = ['input', 'include'];
+
+// Custom parser with eqref macro registered (same signature as \ref: starred + mandatory arg).
+const customParser = getParser({
+    macros: {
+        eqref: { signature: "s m" },
+        tag: { signature: "s m" },
+    }
+});
+const parse = (str: string) => customParser.parse(str);
 
 export class Loader {
     readonly visitedFiles: Set<string> = new Set();

--- a/src/compiler/metadata/equation-label-assigner.ts
+++ b/src/compiler/metadata/equation-label-assigner.ts
@@ -2,19 +2,79 @@ import {Node} from "@unified-latex/unified-latex-types";
 import {VisitInfo} from "@unified-latex/unified-latex-util-visit";
 import {match} from "@unified-latex/unified-latex-util-match";
 import {LabelAssigner} from "./label-assigner";
+import {getCustomTag, getEnvName, hasNonumber, multiRowMathEnvironments, splitMathRows} from "../util";
 
 
-// Equations are not considered to be environments, so they require an additional layer.
-// I will bravely assume that no part of an equation can receive a label.
+// Numbered equation environments that can receive labels.
+const numberedEquationEnvironments = new Set<string>(['equation', 'align', 'multline', 'gather', 'flalign']);
+
+
+// Assigns labels to display math and numbered equation environments.
 export class EquationLabelAssigner extends LabelAssigner {
     visit(node: Node, visitInfo: VisitInfo) {
-        if (!(match.math(node) && node.type === "displaymath")) return;
+        const isDisplayMath = match.math(node) && node.type === "displaymath";
+        const isMathEnv = match.anyEnvironment(node) && node.type === 'mathenv';
 
+        if (!isDisplayMath && !(isMathEnv && numberedEquationEnvironments.has(getEnvName(node.env)))) return;
+
+        const envName = isMathEnv ? getEnvName(node.env) : undefined;
+
+        // Multi-row environments (align): each row can have its own label.
+        if (envName && multiRowMathEnvironments.has(envName)) {
+            const rows = splitMathRows(node.content);
+            const rowData: { label?: string }[] = [];
+            let firstLabel: string | undefined;
+            const additionalLabels: string[] = [];
+
+            for (const row of rows) {
+                let rowLabel: string | undefined;
+                for (const child of row) {
+                    if (match.macro(child, 'label')) {
+                        rowLabel = this.parseLabel(child);
+                    }
+                }
+                const customTag = getCustomTag(row);
+                const nonumber = hasNonumber(row);
+                rowData.push({
+                    label: rowLabel,
+                    ...(customTag !== undefined ? { customTag } : {}),
+                    ...(nonumber ? { nonumber: true } : {}),
+                });
+
+                if (rowLabel) {
+                    if (!firstLabel) {
+                        firstLabel = rowLabel;
+                    } else {
+                        additionalLabels.push(rowLabel);
+                        // Register additional labels as witnessed so they can't be reused.
+                        // The first label is registered by assignLabel() below.
+                        this.witnessedLabels.add(rowLabel);
+                    }
+                }
+            }
+
+            node.meta = {
+                ...node.meta,
+                equationRows: rowData,
+                ...(additionalLabels.length > 0 ? { additionalLabels } : {}),
+            };
+
+            // Use assignLabel for the primary label (sets meta.label and registers in witnessedLabels).
+            this.assignLabel(node, firstLabel);
+            return;
+        }
+
+        // Single-row environments (equation) and display math.
         let label: string | undefined;
         for (const child of node.content) {
             if (!match.macro(child, 'label')) continue;
-
             label = this.parseLabel(child);
+        }
+
+        // Detect custom \tag{} for single equations.
+        const customTag = getCustomTag(node.content);
+        if (customTag !== undefined) {
+            node.meta = { ...node.meta, customTag };
         }
 
         this.assignLabel(node, label);

--- a/src/compiler/metadata/label-assigner.ts
+++ b/src/compiler/metadata/label-assigner.ts
@@ -36,8 +36,9 @@ export abstract class LabelAssigner extends DocumentVisitor {
 
     assignLabel(node: Node, label: string | undefined): void {
         if (!label) {
-            // Only warn if the node is not a math block.
+            // Only warn if the node is not a math block or equation environment.
             if (match.math(node) && node.type === "displaymath") return;
+            if (match.anyEnvironment(node) && node.type === "mathenv") return;
             if (match.environment(node, "tikzcd")) return;
 
             this.addWarning('Node received no label.');

--- a/src/compiler/metadata/numberer.ts
+++ b/src/compiler/metadata/numberer.ts
@@ -6,6 +6,7 @@ import {VisitInfo} from "@unified-latex/unified-latex-util-visit";
 import {match} from "@unified-latex/unified-latex-util-match";
 import {ParserLogger} from "../logging-base";
 import {documentDividers} from "../../unit-types";
+import {getEnvName, multiRowMathEnvironments, splitMathRows} from "../util";
 import consola from "consola";
 
 export class Numberer extends DocumentVisitor {
@@ -45,10 +46,40 @@ export class Numberer extends DocumentVisitor {
                 numbering: this.countManager.increment(this.macroCounters.get(node.content)!!)
             };
         }
-        if (match.anyEnvironment(node) && this.environmentCounters.has(node.env)) {
-            node.meta = {
-                ...node.meta,
-                numbering: this.countManager.increment(this.environmentCounters.get(node.env)!!)
+        const envName = match.anyEnvironment(node) ? getEnvName(node.env) : undefined;
+        if (envName && this.environmentCounters.has(envName)) {
+            const counter = this.environmentCounters.get(envName)!!;
+
+            // Multi-row environments: increment once per row and store per-row numberings.
+            // Rows with \nonumber or custom \tag{} do not increment the counter.
+            if (multiRowMathEnvironments.has(envName)) {
+                const rows = splitMathRows((node as any).content);
+                const existingRows = (node.meta as any)?.equationRows as { label?: string; numbering?: number[]; customTag?: string; nonumber?: boolean }[] | undefined;
+                let firstNumbering: number[] | undefined;
+                const equationRows = rows.map((_, i) => {
+                    const existing = existingRows && existingRows[i] ? existingRows[i] : {};
+                    if (existing.nonumber || existing.customTag) {
+                        return { ...existing };
+                    }
+                    const numbering = this.countManager.increment(counter);
+                    if (!firstNumbering) firstNumbering = numbering;
+                    return { ...existing, numbering };
+                });
+                node.meta = {
+                    ...node.meta,
+                    numbering: firstNumbering,
+                    equationRows,
+                };
+            } else {
+                // Custom \tag{} — don't increment the counter.
+                if ((node.meta as any)?.customTag) {
+                    // No numbering assigned; the custom tag is used instead.
+                } else {
+                    node.meta = {
+                        ...node.meta,
+                        numbering: this.countManager.increment(counter)
+                    }
+                }
             }
         }
     }

--- a/src/compiler/metadata/ref-assigner.ts
+++ b/src/compiler/metadata/ref-assigner.ts
@@ -2,12 +2,12 @@ import {DocumentVisitor} from "../visitor";
 import {Environment, Macro, Node} from "@unified-latex/unified-latex-types";
 import {VisitInfo} from "@unified-latex/unified-latex-util-visit";
 import {match} from "@unified-latex/unified-latex-util-match";
-import {capitaliseFirstLetter, getArgumentText} from "../util";
+import {capitaliseFirstLetter, getArgumentText, getEnvName} from "../util";
 import {ParserLogger} from "../logging-base";
 
 
 // Injects necessary metadata for ref, autoref, and hyperref.
-export const refCommands = new Set<string>(['ref', 'autoref', 'hyperref']);
+export const refCommands = new Set<string>(['ref', 'autoref', 'hyperref', 'eqref']);
 
 
 export class RefAssigner extends DocumentVisitor {
@@ -42,7 +42,7 @@ export class RefAssigner extends DocumentVisitor {
             this.addWarning(`Missing name for the macro ${macro}. Capitalising its first letter to fill in.`);
             return capitaliseFirstLetter(macro);
         } else {
-            const env = node.env;
+            const env = getEnvName(node.env);
             if (this.environmentNames.has(env)) {
                 return this.environmentNames.get(env)!!;
             }
@@ -50,6 +50,27 @@ export class RefAssigner extends DocumentVisitor {
             this.addWarning(`Missing name for the environment ${env}. Capitalising its first letter to fill in.`);
             return capitaliseFirstLetter(env);
         }
+    }
+
+    // For multi-row math environments (align), find the numbering for a specific label.
+    // Handles custom \tag{} and falls back to the node's primary numbering.
+    getNumberingForLabel(targetNode: Node, label: string): string {
+        const meta = targetNode.meta as any;
+
+        // Check multi-row equation data first (align environments).
+        if (meta?.equationRows) {
+            for (const row of meta.equationRows) {
+                if (row.label === label) {
+                    if (row.customTag) return row.customTag;
+                    if (row.numbering) return row.numbering.join('.');
+                }
+            }
+        }
+
+        // Single equation with custom \tag{}.
+        if (meta?.customTag) return meta.customTag;
+
+        return meta?.numbering ? meta.numbering.join('.') : '';
     }
 
     visit(node: Node, visitInfo: VisitInfo): void {
@@ -96,10 +117,21 @@ export class RefAssigner extends DocumentVisitor {
             return;
         }
 
+        // For multi-row environments (align), look up the specific row's numbering by label.
+        const numbering = this.getNumberingForLabel(targetNode, referenceLabel);
+
         if (node.content === 'ref') {
             node.refMeta = {
                 targetTag,
-                text: targetNode.meta.numbering ? targetNode.meta.numbering.join('.') : '',
+                text: numbering,
+            };
+            return;
+        }
+
+        if (node.content === 'eqref') {
+            node.refMeta = {
+                targetTag,
+                text: `(${numbering})`,
             };
             return;
         }
@@ -108,7 +140,7 @@ export class RefAssigner extends DocumentVisitor {
             // In the case of autoref, the name of the node is required to generate the text of the ref.
             node.refMeta = {
                 targetTag,
-                text: `${this.getNodeName(targetNode)} ${targetNode.meta.numbering ? targetNode.meta.numbering.join('.') : ''}`
+                text: `${this.getNodeName(targetNode)} ${numbering}`
             };
             return;
         }

--- a/src/compiler/metadata/tag-assigner.ts
+++ b/src/compiler/metadata/tag-assigner.ts
@@ -4,6 +4,7 @@ import {VisitInfo} from "@unified-latex/unified-latex-util-visit";
 import {match} from "@unified-latex/unified-latex-util-match";
 import {nextSafeTag} from "../../tag";
 import {ParserLogger} from "../logging-base";
+import {getArgumentText, getEnvName} from "../util";
 
 
 // In the present system, each unit, such as a chapter, section, or a theorem, will be assigned a unique ID known as a
@@ -16,12 +17,19 @@ export class TagAssigner extends DocumentVisitor {
 
     taggableMacros: Set<string>;
     taggableEnvironments: Set<string>;
+    // Environments that are tagged for anchoring but do not become units (e.g. equations).
+    // These should NOT receive synthetic labels since their tags are transient.
+    nonUnitEnvironments: Set<string>;
 
-    constructor({ labelTagMap, nextAvailableTag, taggableMacros, taggableEnvironments, logger }: {
+    // Disambiguator for synthetic labels that share the same base key.
+    private syntheticCounters: Map<string, number>;
+
+    constructor({ labelTagMap, nextAvailableTag, taggableMacros, taggableEnvironments, nonUnitEnvironments, logger }: {
         labelTagMap?: Map<string, number>;
         nextAvailableTag?: number;
         taggableMacros?: Set<string>;
         taggableEnvironments?: Set<string>;
+        nonUnitEnvironments?: Set<string>;
         logger?: ParserLogger
     }) {
         super({ logger });
@@ -31,6 +39,9 @@ export class TagAssigner extends DocumentVisitor {
 
         this.taggableMacros = taggableMacros ?? new Set<string>();
         this.taggableEnvironments = taggableEnvironments ?? new Set<string>();
+        this.nonUnitEnvironments = nonUnitEnvironments ?? new Set<string>();
+
+        this.syntheticCounters = new Map<string, number>();
 
         if (nextAvailableTag) {
             this.nextAvailableTag = nextAvailableTag;
@@ -39,33 +50,76 @@ export class TagAssigner extends DocumentVisitor {
         }
     }
 
+    // Build a stable synthetic label from the node's type and title text.
+    // This lets unlabeled units keep the same tag across recompiles as long as
+    // their title doesn't change.
+    private generateSyntheticLabel(node: Node): string {
+        let type: string;
+        let titleParts: string[];
+
+        if (match.anyMacro(node)) {
+            type = node.content;
+            titleParts = node.args ? node.args.map(a => getArgumentText(a)) : [];
+        } else {
+            type = getEnvName((node as any).env);
+            titleParts = (node as any).args
+                ? (node as any).args.map((a: any) => getArgumentText(a))
+                : [];
+        }
+
+        const title = titleParts.filter(t => t.length > 0).join(':');
+        const baseKey = `__auto:${type}:${title}`;
+        const count = (this.syntheticCounters.get(baseKey) ?? 0) + 1;
+        this.syntheticCounters.set(baseKey, count);
+
+        return count === 1 ? baseKey : `${baseKey}:#${count}`;
+    }
+
+    private assignTag(node: Node, label: string): void {
+        if (this.labelTagMap.has(label)) {
+            node.meta = { ...node.meta, label };
+            node.meta.tag = this.labelTagMap.get(label);
+        } else {
+            node.meta = { ...node.meta, label, tag: this.nextAvailableTag };
+            this.labelTagMap.set(label, this.nextAvailableTag);
+            this.nextAvailableTag = nextSafeTag(this.nextAvailableTag + 1);
+        }
+    }
+
     visit(node: Node, visitInfo: VisitInfo): void {
-        if (!((match.anyEnvironment(node) && this.taggableEnvironments.has(node.env)) ||
+        if (!((match.anyEnvironment(node) && this.taggableEnvironments.has(getEnvName(node.env))) ||
             (match.anyMacro(node) && this.taggableMacros.has(node.content)))) return;
 
-        // If a label is already present, attempt to acquire it.
         if (node.meta && node.meta.label) {
-            if (this.labelTagMap.has(node.meta.label)) {
-                node.meta.tag = this.labelTagMap.get(node.meta.label);
-            } else {
-                node.meta.tag = this.nextAvailableTag;
-                this.labelTagMap.set(node.meta.label, node.meta.tag);
+            // Node already has a user-assigned label — use it for tag lookup.
+            this.assignTag(node, node.meta.label);
+        } else {
+            // No label. For unit nodes (chapters, sections, theorems, etc.), generate
+            // a synthetic label so the tag is stable across recompiles.
+            // For non-unit nodes (equations), just assign a fresh tag.
+            const isNonUnit = match.anyEnvironment(node) &&
+                this.nonUnitEnvironments.has(getEnvName(node.env));
 
+            if (!isNonUnit) {
+                this.assignTag(node, this.generateSyntheticLabel(node));
+            } else {
+                node.meta = { ...node.meta, tag: this.nextAvailableTag };
                 this.nextAvailableTag = nextSafeTag(this.nextAvailableTag + 1);
             }
-        } else {
-            this.addWarning('Node does not have a label, and will receive a new tag.')
+        }
 
-            // Otherwise, make a brand new tag for the node.
-            node.meta = {
-                ...node.meta,
-                tag: this.nextAvailableTag
-            };
-
-            this.nextAvailableTag = nextSafeTag(this.nextAvailableTag + 1);
+        // Register additional labels (from multi-row math environments like align)
+        // to point to the same tag.
+        const meta = node.meta as any;
+        if (meta.additionalLabels) {
+            for (const extraLabel of meta.additionalLabels) {
+                if (!this.labelTagMap.has(extraLabel)) {
+                    this.labelTagMap.set(extraLabel, node.meta!.tag!!);
+                }
+            }
         }
 
         // At this point the tag should be assigned already.
-        this.tagNodeMap.set(node.meta.tag!!, node);
+        this.tagNodeMap.set(node.meta!.tag!!, node);
     }
 }

--- a/src/compiler/renderer/math-renderer.ts
+++ b/src/compiler/renderer/math-renderer.ts
@@ -7,6 +7,8 @@ import {printRaw} from "@unified-latex/unified-latex-util-print-raw";
 import {htmlLike} from "@unified-latex/unified-latex-util-html-like";
 import {classes} from "./classes";
 import {ParserLogger} from "../logging-base";
+import {getEnvName, multiRowMathEnvironments, splitMathRows} from "../util";
+import {toTagString} from "../../tag";
 
 import {createSyncFn} from "synckit";
 import { resolve } from 'path';
@@ -15,6 +17,11 @@ const tikz2Svg = createSyncFn(
     resolve(__dirname, './tikz-worker')
 );
 
+// Ref commands that can appear inside math and should be resolved by the compiler
+// rather than left for MathJax (which can only resolve labels on the same page).
+const mathRefCommands = new Set<string>(['ref', 'eqref']);
+
+
 export class MathRenderer extends NodeRenderer {
     preambleDump: string;
 
@@ -22,6 +29,27 @@ export class MathRenderer extends NodeRenderer {
         super({ logger });
 
         this.preambleDump = preambleDump ?? '';
+    }
+
+    // Resolve refs and strip labels from math content before passing to MathJax.
+    // This ensures equation references are context-independent (the compiler's numbering
+    // is used, not MathJax's page-local label resolution) and prevents namespace
+    // conflicts when the same equation appears on multiple unit pages.
+    private resolveMathContent(content: Node[]): string {
+        return content.map((c: Node) => {
+            // Replace \ref and \eqref with compiler-resolved text.
+            if (match.anyMacro(c) && mathRefCommands.has(c.content)
+                && c.refMeta && typeof c.refMeta.text === 'string') {
+                return c.refMeta.text;
+            }
+            // Strip \label — the compiler manages labels, not MathJax.
+            if (match.macro(c, 'label')) return '';
+            // Strip \nonumber — the compiler controls numbering via \tag{}.
+            if (match.macro(c, 'nonumber')) return '';
+            // Strip \tag — already handled or passed through by the renderer.
+            if (match.macro(c, 'tag')) return '';
+            return printRaw(c);
+        }).join('');
     }
 
     isTikzPicture(node: DisplayMath) {
@@ -52,10 +80,13 @@ export class MathRenderer extends NodeRenderer {
     render(node: Node): Node | void {
         if (match.math(node)) {
             if (node.type === 'inlinemath') {
-                // Inline math gets printed out directly.
+                // Inline math: resolve any \ref/\eqref and strip \label before
+                // passing to MathJax, so refs work regardless of which unit page
+                // the math appears on.
+                const inner = this.resolveMathContent(node.content);
                 return {
                     type: 'string',
-                    content: printRaw(node)
+                    content: `$${inner}$`
                 };
             }
 
@@ -66,7 +97,8 @@ export class MathRenderer extends NodeRenderer {
             }
 
 
-            // Here it would have to be display math. In which case the content will be wrapped inside a div.
+            // Display math: resolve refs and strip labels.
+            const displayInner = this.resolveMathContent(node.content);
             return htmlLike({
                 tag: 'div',
                 attributes: {
@@ -74,13 +106,78 @@ export class MathRenderer extends NodeRenderer {
                 },
                 content: {
                     type: 'string',
-                    content: printRaw(node)
+                    content: `\\[${displayInner}\\]\n`
                 }
             });
         }
 
         // Here it would be an align environment or something of this kind.
         if (match.anyEnvironment(node) && node.type === 'mathenv') {
+            // For numbered equation environments, inject \tag{N} so the displayed number
+            // matches the custom numbering system. Labels are stripped (the compiler
+            // resolves all refs) to avoid namespace conflicts across unit pages.
+            if (getEnvName(node.env) === 'equation' && node.meta) {
+                const hasCustomTag = !!(node.meta as any).customTag;
+                const hasNumbering = !!node.meta.numbering;
+
+                if (hasCustomTag || hasNumbering) {
+                    const rawContent = this.resolveMathContent(node.content);
+                    // Re-inject custom \tag{} or use auto-numbering.
+                    const tagDirective = hasCustomTag
+                        ? `\\tag{${(node.meta as any).customTag}}`
+                        : `\\tag{${node.meta.numbering!.join('.')}}`;
+                    return htmlLike({
+                        tag: 'div',
+                        attributes: {
+                            class: classes.displayEquation,
+                            ...(node.meta.tag ? { id: `eq-${toTagString(node.meta.tag)}` } : {}),
+                        },
+                        content: {
+                            type: 'string',
+                            content: `\\begin{equation}${tagDirective}${rawContent}\\end{equation}\n`
+                        }
+                    });
+                }
+            }
+
+            const envName = getEnvName(node.env);
+
+            // Multi-row environments (align): inject \tag{N} per row.
+            if (multiRowMathEnvironments.has(envName) && node.meta?.equationRows) {
+                const rows = splitMathRows(node.content);
+                const equationRows = (node.meta as any).equationRows as { numbering?: number[]; label?: string; customTag?: string; nonumber?: boolean }[];
+
+                const renderedRows = rows.map((row, i) => {
+                    const rowContent = this.resolveMathContent(row);
+                    const rowData = equationRows[i];
+                    let tag = '';
+                    if (rowData?.customTag) {
+                        // Re-inject the custom \tag since resolveMathContent stripped it.
+                        tag = `\\tag{${rowData.customTag}}`;
+                    } else if (rowData?.nonumber) {
+                        // No tag, no number.
+                        tag = '\\notag';
+                    } else if (rowData?.numbering) {
+                        tag = `\\tag{${rowData.numbering.join('.')}}`;
+                    }
+                    return `${tag}${rowContent}`;
+                });
+
+                return htmlLike({
+                    tag: 'div',
+                    attributes: {
+                        class: classes.displayEquation,
+                        ...(node.meta.tag ? { id: `eq-${toTagString(node.meta.tag)}` } : {}),
+                    },
+                    content: {
+                        type: 'string',
+                        content: `\\begin{${envName}}${renderedRows.join('\\\\')}\\end{${envName}}\n`
+                    }
+                });
+            }
+
+            // Generic fallback for other math environments.
+            const mathEnvContent = this.resolveMathContent(node.content);
             return htmlLike({
                 tag: 'div',
                 attributes: {
@@ -88,7 +185,7 @@ export class MathRenderer extends NodeRenderer {
                 },
                 content: {
                     type: 'string',
-                    content: printRaw(node)
+                    content: `\\begin{${envName}}${mathEnvContent}\\end{${envName}}\n`
                 }
             })
         }

--- a/src/compiler/renderer/ref-renderer.ts
+++ b/src/compiler/renderer/ref-renderer.ts
@@ -6,7 +6,7 @@ import {classes} from "./classes";
 import {toTagString} from "../../tag";
 
 
-const refCommands = new Set<string>(['ref', 'autoref', 'hyperref']);
+const refCommands = new Set<string>(['ref', 'autoref', 'hyperref', 'eqref']);
 
 
 export class RefRenderer extends NodeRenderer {
@@ -18,10 +18,15 @@ export class RefRenderer extends NodeRenderer {
         }
 
         if (node.refMeta.targetTag >= 0) {
+            // If the target is inside a unit (e.g. an equation inside a section),
+            // link to the parent unit's page with an anchor to the target element.
+            const href = node.refMeta.parentTag !== undefined
+                ? `/t/${toTagString(node.refMeta.parentTag)}#${node.refMeta.anchor}`
+                : `/t/${toTagString(node.refMeta.targetTag)}`;
             return htmlLike({
                 tag: 'a',
                 attributes: {
-                    href: `/t/${toTagString(node.refMeta.targetTag)}`,
+                    href,
                     class: classes.ref
                 },
                 content: typeof node.refMeta.text === 'string' ? {

--- a/src/compiler/util.ts
+++ b/src/compiler/util.ts
@@ -1,4 +1,5 @@
 import {Argument, Macro, Node} from "@unified-latex/unified-latex-types";
+import {match} from "@unified-latex/unified-latex-util-match";
 import {NodeContext} from "./error";
 import {printRaw} from "@unified-latex/unified-latex-util-print-raw";
 
@@ -25,4 +26,49 @@ export function getArgumentTexts(macro: Macro): string[] {
 
 export function capitaliseFirstLetter(text: string): string {
     return text.length === 0 ? text : text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+// Multi-row math environments (align, gather) have rows separated by \\ macros.
+// These are the environments where each row gets its own equation number.
+export const multiRowMathEnvironments = new Set<string>(['align', 'gather', 'flalign']);
+
+// Split a math environment's flat content array into per-row segments.
+// Rows are delimited by \\ macros (line breaks).
+export function splitMathRows(content: Node[]): Node[][] {
+    const rows: Node[][] = [[]];
+    for (const node of content) {
+        if (match.anyMacro(node) && /^\\+$/.test(node.content)) {
+            rows.push([]);
+        } else {
+            rows[rows.length - 1].push(node);
+        }
+    }
+    // Remove trailing empty row (common when align ends with \\).
+    if (rows.length > 1 && rows[rows.length - 1].every(
+        n => n.type === 'whitespace' || (n.type === 'string' && n.content.trim() === '')
+    )) {
+        rows.pop();
+    }
+    return rows;
+}
+
+// Check if a list of nodes contains \nonumber.
+export function hasNonumber(nodes: Node[]): boolean {
+    return nodes.some(n => match.macro(n, 'nonumber'));
+}
+
+// Extract the text of a \tag{...} macro from a list of nodes, if present.
+export function getCustomTag(nodes: Node[]): string | undefined {
+    for (const n of nodes) {
+        if (match.macro(n, 'tag') && n.args && n.args[1]) {
+            return getArgumentText(n.args[1]);
+        }
+    }
+    return undefined;
+}
+
+// Normalise the env name of an environment or mathenv node to a plain string.
+// Regular environments have env as a string, but mathenv nodes have env as an AST object.
+export function getEnvName(env: any): string {
+    return typeof env === 'string' ? env : printRaw(env);
 }

--- a/src/components/LinkList.tsx
+++ b/src/components/LinkList.tsx
@@ -4,6 +4,7 @@ import {JSX} from "solid-js";
 export interface LinkListItem {
     content: string | JSX.Element;
     href: string;
+    children?: LinkListItem[];
 }
 
 
@@ -15,15 +16,20 @@ export interface LinkListProps {
 export function LinkList(props: LinkListProps) {
     return <div class={'link-list-container'}>
         { props.title? <h3>{props.title}</h3> : null }
-        <ul class={'link-list'}>
-            {props.items.map(item => <li class={'link-list-item'}>
-                {
-                    typeof item.content === 'string' ? <a href={item.href} class={'link-primary'} innerHTML={item.content}/> :
-                        <a href={item.href} class={'link-primary'}>{item.content}</a>
-                }
-            </li>)}
-        </ul>
+        <LinkListUl items={props.items}/>
     </div>
+}
+
+function LinkListUl(props: { items: LinkListItem[] }) {
+    return <ul class={'link-list'}>
+        {props.items.map(item => <li class={'link-list-item'}>
+            {
+                typeof item.content === 'string' ? <a href={item.href} class={'link-primary'} innerHTML={item.content}/> :
+                    <a href={item.href} class={'link-primary'}>{item.content}</a>
+            }
+            {item.children && item.children.length > 0 ? <LinkListUl items={item.children}/> : null}
+        </li>)}
+    </ul>
 }
 
 

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -45,7 +45,11 @@ export function Page(props: PageProps) {
         }
 
         <Title>{props.titleText}</Title>
-        <div class={`page-container ${config()?.website.font}`}>
+        <div class={`page-container ${config()?.website.font}`} style={{
+            'font-size': `${config()?.website.fontSize ?? 16}px`,
+            'line-height': `${config()?.website.lineHeight ?? 1.3}`,
+            'max-width': `calc(${config()?.website.contentWidth ?? 120} * 0.5rem)`,
+        }}>
             <Topbar/>
             {
                 props.parentChain && props.parentChain.length ?

--- a/src/components/UnitLinkList.tsx
+++ b/src/components/UnitLinkList.tsx
@@ -7,10 +7,17 @@ export interface UnitLinkListProps {
     items: LinkTarget[],
 }
 
-export function UnitLinkList(props: UnitLinkListProps) {
-    return <LinkList title={props.title} items={props.items.map((t) => ({
+function linkTargetToItem(t: LinkTarget): { content: string; href: string; children?: { content: string; href: string; children?: any }[] } {
+    return {
         content: linkHTML(t),
-        href: `/t/${toTagString(t.tag)}`
-    }))}/>
+        href: `/t/${toTagString(t.tag)}`,
+        ...(t.children && t.children.length > 0
+            ? { children: t.children.map(linkTargetToItem) }
+            : {})
+    };
+}
+
+export function UnitLinkList(props: UnitLinkListProps) {
+    return <LinkList title={props.title} items={props.items.map(linkTargetToItem)}/>
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,9 @@ export const SpecConfigSchema = z.object({
 
     website: z.object({
         font: z.enum(['roboto', 'open-sans', 'cmu-serif', 'cmu-sans-serif']).default('cmu-serif'),
+        fontSize: z.number().min(10).max(28).default(16),
+        lineHeight: z.number().min(1).max(3).default(1.3),
+        contentWidth: z.number().min(40).max(200).default(120),
         primaryColour: z.enum(['red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan', 'sky',
             'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose']).default('blue'),
         neutralColour: z.enum(['slate', 'grey', 'zinc', 'stone']).default('grey'),

--- a/src/db/link-target.ts
+++ b/src/db/link-target.ts
@@ -6,6 +6,9 @@ export interface LinkTarget {
 
     // HTML title, if it exists.
     titleHtml?: string;
+
+    // Nested children (subsections inside sections, etc.)
+    children?: LinkTarget[];
 }
 
 

--- a/src/types/unified-latex.ts
+++ b/src/types/unified-latex.ts
@@ -9,15 +9,32 @@ export interface LabeledElementMetadata extends ElementMetadata {
     label?: string;
     tag?: number;
     numbering?: number[];
+    customTag?: string;   // user-specified \tag{...} overrides auto-numbering
 }
+// Per-row data for multi-row math environments (align, gather, etc.).
+export interface EquationRowData {
+    label?: string;
+    numbering?: number[];
+    customTag?: string;   // user-specified \tag{...} overrides auto-numbering
+    nonumber?: boolean;   // \nonumber suppresses numbering for this row
+}
+
 export interface TheoremMetadata extends LabeledElementMetadata {
     title?: Node[]; // Theorems/lemmas may come with a title.
     proofs?: Environment[];
+    // For multi-row math environments like align, stores per-row labels and numberings.
+    equationRows?: EquationRowData[];
+    // Additional labels beyond meta.label that map to this node's tag.
+    additionalLabels?: string[];
 }
 export interface RefMetadata {
     // Since the ref metadata is created in one step, the fields here will not be optional.
     targetTag: number;
     text: Node[] | string;
+    // For targets that are not standalone units (e.g. equations inside a section),
+    // parentTag points to the containing unit's page and anchor is the fragment ID.
+    parentTag?: number;
+    anchor?: string;
 }
 
 


### PR DESCRIPTION
- Support \begin{equation}, align, multline, gather, flalign environments with automatic numbering, \label, \ref, \autoref, \eqref resolution
- Handle \nonumber and custom \tag{} in multi-row math environments
- Resolve equation links to parent unit pages with anchors (no more 404s)
- Add stable synthetic labels for unlabeled units to prevent tag drift
- Add client-side reload guard: redirects home if page no longer exists
- Add SSE live-reload server for watch mode (auto-refresh on .tex save)
- Add subsection/subsubsection nesting in chapter sidebar menu
- Add fontSize, lineHeight, contentWidth options in spec.toml [website]
- Register \eqref and \tag macros with the parser for correct arg parsing